### PR TITLE
Create directory specified as output when not present and ignore cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+## Ignore library caches
+__pycache__
+*.egg-info

--- a/helper_code/models/regression/train_rf_regression_full_cv.py
+++ b/helper_code/models/regression/train_rf_regression_full_cv.py
@@ -3,6 +3,7 @@ from pyspark.sql import SparkSession
 import pandas as pd
 import numpy as np
 
+from os import makedirs
 from os.path import join
 from sklearn.ensemble import RandomForestRegressor
 import joblib
@@ -134,5 +135,6 @@ if __name__ == '__main__':
     parser.add_argument('--is-log', action='store_true', help="Defines if the label should be log transformed.")
 
     args = vars(parser.parse_args())
+    makedirs(args['output_dir'], exist_ok=True)
 
     main(args)


### PR DESCRIPTION
Creates the output directory specified as part of `train_rf_regression_full_cv.py` and ignores the cache and info files from installing the repository as a library.

This does not adjust the README about the need for a JAR to use spark.